### PR TITLE
easydbus is a C project file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 2.6)
-project(easydbus)
+project(easydbus C)
 
 add_definitions("-Wall -Wextra -Wno-unused-parameter")
 set(CMAKE_C_FLAGS_RELEASE "-O2")


### PR DESCRIPTION
Specify that easydbus is a C project file otherwise build will fail if
no C++ compiler is found by cmake

Fixes:
 - http://autobuild.buildroot.org/results/486c3cd98124e7415dee2fd1463bd5e0fcc9ba91

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>