### PR TITLE
bus: Pass object name to the signal handler

### DIFF
--- a/src/bus.c
+++ b/src/bus.c
@@ -734,7 +734,11 @@ static void signal_callback(GDBusConnection *conn,
         lua_rawgeti(L, 1, i);
     }
 
-    ret = ed_resume(L, n_args + push_tuple(L, parameters, NULL) - 1);
+    n_args += push_tuple(L, parameters, NULL) - 1;
+    lua_pushstring(L, object_name);
+    n_args++;
+
+    ret = ed_resume(L, n_args);
     if (ret && ret != LUA_YIELD)
         g_warning("signal handler error: %s", lua_tostring(L, -1));
 


### PR DESCRIPTION
This is quite helpful to find out the object whose properties have changed. Tested with NetworkManager:

```lua
local dbus = require("easydbus")
local bus = dbus.system()

local function properties_changed(interface, changed, invalidated, path)
  local next = next
  print(("[ %s ]"):format(interface))
  print(("  Path = %s"):format(path))
  if next(changed) ~= nil then
    print("  Changed:")
    for k, v in pairs(changed) do print(("    %s = %s"):format(k, v)) end
  end
  if next(invalidated) ~= nil then
    print("  Invalidated:")
    for _, v in pairs(invalidated) do print(("    %s"):format(v)) end
  end
end

bus:subscribe(nil, nil, "org.freedesktop.DBus.Properties", "PropertiesChanged", properties_changed)

dbus.mainloop()
```

For example:

```
[ org.freedesktop.NetworkManager.AccessPoint ]
  Path = /org/freedesktop/NetworkManager/AccessPoint/24
  Changed:
    Strength = 87
```